### PR TITLE
fixed multi-byte problem

### DIFF
--- a/lib/fancy_irb.rb
+++ b/lib/fancy_irb.rb
@@ -106,7 +106,9 @@ class << FancyIrb
   def track_height(data)
     lines      = data.to_s.count("\n")
     long_lines = data.to_s.split("\n").inject(0){ |sum, line|
-      line_size = (RUBY_VERSION[2] == ?8) ? line.unpack('U*').size : line.size
+      line_size = line.chars.inject(0) do |mem, chr|
+        mem + ((chr.bytesize rescue chr.size) > 1 ? 2 : 1)
+      end
       sum + (line_size / `tput cols`.to_i)
     }
     @height_counter << lines + long_lines

--- a/lib/fancy_irb/irb_ext.rb
+++ b/lib/fancy_irb/irb_ext.rb
@@ -33,7 +33,10 @@ module IRB
         # get lengths
         last_input               = @scanner.instance_variable_get( :@line )
         last_line_without_prompt = last_input.split("\n").last
-        offset = last_line_without_prompt.size + FancyIrb.real_lengths[:input_prompt] + 1
+        line_size = last_line_without_prompt.chars.inject(0) do |mem, chr|
+          mem + ((chr.bytesize rescue chr.size) > 1 ? 2 : 1 )
+        end
+        offset = line_size + FancyIrb.real_lengths[:input_prompt] + 1
         screen_length = `tput cols`.to_i
         screen_lines = `tput lines`.to_i
         output_length = FancyIrb.real_lengths[:output]


### PR DESCRIPTION
Thank you for quick reply. but was same result for both 1.8 & 1.9.

a multi-byte char consumes almost double width of asciis' in a line.
so, not only long lines but also short have same issue as follows:

input a string with multi-byte chars like:
    "あいう"
then hit a return key, you will get like:
    "あい#=> "あいう"

it may be another good solution for it, but works for me. : -)
