### PR TITLE
fix for undefined method bug on irb exit

### DIFF
--- a/lib/fancy_irb/irb_ext.rb
+++ b/lib/fancy_irb/irb_ext.rb
@@ -49,7 +49,10 @@ module IRB
         # get lengths
         last_input               = @scanner.instance_variable_get( :@line )
         last_line_without_prompt = last_input.split("\n").last
-        offset = last_line_without_prompt.display_size + FancyIrb.real_lengths[:input_prompt] + 1
+        offset =  + FancyIrb.real_lengths[:input_prompt] + 1
+        if last_line_without_prompt
+          offset += last_line_without_prompt.display_size
+        end
         screen_length = FancyIrb.current_length
         screen_lines  = FancyIrb.current_lines
         output_length = FancyIrb.real_lengths[:output]


### PR DESCRIPTION
check that last_line_without_prompt is != nil before attempting to call display_size on it

this fixes a bug which can be reproduced as follows:

open irb, press enter two times, press ctrl-d twice to exit.

~ > cat .irbrc
require 'fancy_irb'
FancyIrb.start

~ > irb
ruby-1.9.2-p290 :001 > 
ruby-1.9.2-p290 :002 >  
ruby-1.9.2-p290 :003 >   ^D
ruby-1.9.2-p290 :003 > ^D
NoMethodError: undefined method `display_size' for nil:NilClass
    from /Users/rjs/.rvm/gems/ruby-1.9.2-p290/gems/fancy_irb-0.7.1/lib/fancy_irb/irb_ext.rb:52:in`output_value'
    from /Users/rjs/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb.rb:160:in `block (2 levels) in eval_input'
    from /Users/rjs/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/irb.rb:273:in`signal_status'
    from /Users/rjs/.rvm/gems/ruby-1.9.2-p290/gems/fancy_irb-0.7.1/lib/fancy_irb/irb_ext.rb:101:in `signal_status'
